### PR TITLE
format: storage module (Block, Sstable, WAL)

### DIFF
--- a/include/storage/Block.h
+++ b/include/storage/Block.h
@@ -27,10 +27,10 @@ class Block : public std::enable_shared_from_this<Block> {
   std::optional<std::size_t> get_offset(const std::size_t index);
   std::size_t                get_cur_size() const;
 
-  std::optional<uint64_t>                              get_tranc_id(const std::size_t offset) const;
-  std::optional<std::pair<std::string_view, uint64_t>> get_value_binary(std::string_view key);
-  bool                                                 KeyExists(std::string_view key);
-  std::pair<std::string, std::string>                  get_first_and_last_key();
+  std::optional<uint64_t>                         get_tranc_id(const std::size_t offset) const;
+  std::optional<std::pair<std::string, uint64_t>> get_value_binary(std::string_view key);
+  bool                                            KeyExists(std::string_view key);
+  std::pair<std::string, std::string>             get_first_and_last_key();
   bool          add_entry(const std::string& key, const std::string& value, const uint64_t tranc_id,
                           bool force_write = false);
   bool          is_empty() const;
@@ -51,7 +51,7 @@ class Block : public std::enable_shared_from_this<Block> {
     std::string    value;
     const uint64_t tranc_id;
   };
-  std::string                                          get_key(const std::size_t offset) const;
-  std::optional<std::pair<std::string_view, uint64_t>> get_value(const std::size_t offset) const;
-  std::shared_ptr<Block::Entry>                        get_entry(std::size_t offset);
+  std::string                                     get_key(const std::size_t offset) const;
+  std::optional<std::pair<std::string, uint64_t>> get_value(const std::size_t offset) const;
+  std::shared_ptr<Block::Entry>                   get_entry(std::size_t offset);
 };

--- a/include/storage/Sstable.h
+++ b/include/storage/Sstable.h
@@ -34,9 +34,9 @@ class Sstable : public std::enable_shared_from_this<Sstable> {
   size_t                              get_sst_id() const;
   std::string                         get_first_key() const;
   std::string                         get_last_key() const;
-  std::tuple<std::string, std::string, uint64_t> getValue() const;
-  bool                                           is_block_index_vaild(size_t block_index) const;
-  std::optional<std::pair<std::string_view, uint64_t>> KeyExists(std::string_view key, uint64_t);
+  std::tuple<std::string, std::string, uint64_t>  getValue() const;
+  bool                                            is_block_index_vaild(size_t block_index) const;
+  std::optional<std::pair<std::string, uint64_t>> KeyExists(std::string_view key, uint64_t);
   SstIterator get_Iterator(std::string_view key, uint64_t tranc_id = 0, bool is_prefix = false);
   SstIterator current_Iterator(size_t block_idx, uint64_t tranc_id = 0);
   SstIterator begin(uint64_t tranc_id);

--- a/include/storage/file.h
+++ b/include/storage/file.h
@@ -59,6 +59,7 @@ class FileObj {
   bool append(std::vector<uint8_t>& buf);
 
   bool sync();
+  bool is_open();
   void close();
 
   void validate_read_bounds(size_t offset, size_t data_size) const;

--- a/include/storage/std_file.h
+++ b/include/storage/std_file.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <cstddef>
 #include <filesystem>
-#include <fstream>
 #include <string>
 #include <vector>
 
@@ -9,35 +8,38 @@ class StdFile {
  public:
   StdFile() {}
   ~StdFile() {
-    if (file_.is_open()) {
-      file_.flush();
+    if (is_open()) {
       close();
     }
   }
 
-  // 打开文件并映射到内存
-  bool open(const std::string& filename, bool create);
+  // 禁止拷贝，允许移动
+  StdFile(const StdFile&)            = delete;
+  StdFile& operator=(const StdFile&) = delete;
+  StdFile(StdFile&& other) noexcept : fd_(other.fd_), filename_(std::move(other.filename_)) {
+    other.fd_ = -1;
+  }
+  StdFile& operator=(StdFile&& other) noexcept {
+    if (this != &other) {
+      close();
+      fd_       = other.fd_;
+      filename_ = std::move(other.filename_);
+      other.fd_ = -1;
+    }
+    return *this;
+  }
 
-  // 创建文件
-  bool create(const std::string& filename, const std::vector<uint8_t>& buf);
-  // 读取数据
+  bool                 open(const std::string& filename, bool create);
+  bool                 is_open() const;
+  bool                 create(const std::string& filename, const std::vector<uint8_t>& buf);
   std::vector<uint8_t> read(size_t offset, size_t length);
-  // 关闭文件
-  void close();
-
-  // 获取文件大小
-  size_t size();
-
-  // 写入数据
-  bool write(size_t offset, const void* data, size_t size);
-
-  // 同步到磁盘
-  bool sync();
-
-  // 删除文件
-  bool remove();
+  void                 close();
+  size_t               size() const;
+  bool                 write(size_t offset, const void* data, size_t size);
+  bool                 sync();
+  bool                 remove();
 
  private:
-  std::fstream          file_;
+  int                   fd_ = -1;
   std::filesystem::path filename_;
 };

--- a/include/storage/wal.h
+++ b/include/storage/wal.h
@@ -61,12 +61,18 @@ struct WalEntry {
 //                  MemTable in parallel.
 //    kUnordered  – each writer independently holds write_mutex_ for its own
 //                  entry only; no grouping overhead.
+//
+//  log_batch():
+//    Bypasses the pipelining mechanism and holds write_mutex_ for the entire
+//    span of entries, issuing exactly one fsync at the end.  This is the
+//    preferred path for put_batch / remove_batch where all entries share one
+//    transaction-id and must be atomically durable.
 // ─────────────────────────────────────────────────────────────────────────────
 class WAL {
  public:
-  explicit WAL(std::string_view log_dir, uint64_t checkpoint_tranc_id,
-               uint64_t clean_interval_s = Global_::WAL_CLEAN_INTERVAL_S,
-               uint64_t file_size_limit  = Global_::WAL_FILE_LIMIT);
+  WAL(std::string_view log_dir, uint64_t checkpoint_tranc_id,
+      uint64_t clean_interval_s = Global_::WAL_CLEAN_INTERVAL_S,
+      uint64_t file_size_limit  = Global_::WAL_FILE_LIMIT);
   ~WAL();
 
   WAL(const WAL&)            = delete;
@@ -82,6 +88,13 @@ class WAL {
   // Append one entry and block until it is fsync'd to disk.
   // Dispatches to pipelined or unordered path based on WAL_WRITE_POLICY.
   [[nodiscard]] std::expected<void, WalError> log(const WalEntry& entry);
+
+  // Append a batch of entries with a single fsync.
+  // Holds write_mutex_ for the entire batch regardless of WAL_WRITE_POLICY,
+  // giving atomic durability for all entries in one round-trip to disk.
+  // Returns on the first I/O error; entries written before the error are NOT
+  // rolled back (callers should treat WAL write failure as fatal).
+  [[nodiscard]] std::expected<void, WalError> log_batch(std::span<const WalEntry> entries);
 
   // Force fsync without appending (used on commit / destructor).
   [[nodiscard]] std::expected<void, WalError> flush();

--- a/src/storage/Block.cpp
+++ b/src/storage/Block.cpp
@@ -101,8 +101,7 @@ std::string Block::get_key(const std::size_t offset) const {
   return std::string(reinterpret_cast<const char*>(Data_.data() + offset + sizeof(uint16_t)),
                      key_len);
 }
-std::optional<std::pair<std::string_view, uint64_t>> Block::get_value(
-    const std::size_t offset) const {
+std::optional<std::pair<std::string, uint64_t>> Block::get_value(const std::size_t offset) const {
   if (offset > Offset_[Offset_.size() - 1]) {
     spdlog::info("Block::get_value(const std::size_t offset) {} Invalid offset too much {}", offset,
                  Offset_[Offset_.size() - 1]);
@@ -110,28 +109,27 @@ std::optional<std::pair<std::string_view, uint64_t>> Block::get_value(
   }
 
   // 获取底层字节数据指针（unsigned char 类型）
-  const unsigned char* base = Data_.data();
+  const char* base = reinterpret_cast<const char*>(Data_.data());
 
   // 读取 key_len
   uint16_t key_len;
   std::memcpy(&key_len, base + offset, sizeof(uint16_t));
 
   // value_len 紧跟在 key 数据之后
-  const unsigned char* value_len_ptr = base + offset + sizeof(uint16_t) + key_len;
-  uint16_t             value_len;
+  const char* value_len_ptr = base + offset + sizeof(uint16_t) + key_len;
+  uint16_t    value_len;
   std::memcpy(&value_len, value_len_ptr, sizeof(uint16_t));
 
   // value 数据的起始位置
-  const unsigned char* value_start = value_len_ptr + sizeof(uint16_t);
+  const char* value_start = value_len_ptr + sizeof(uint16_t);
 
   // tr 紧跟在 value 数据之后
-  const unsigned char* tr_ptr = value_start + value_len;
-  uint64_t             tr;
+  const char* tr_ptr = value_start + value_len;
+  uint64_t    tr;
   std::memcpy(&tr, tr_ptr, sizeof(uint64_t));
 
-  // 构造 string_view，需要转换为 const char*
-  std::string_view value_view(reinterpret_cast<const char*>(value_start), value_len);
-  return std::make_pair(value_view, tr);
+  std::string value(reinterpret_cast<const char*>(value_start), value_len);
+  return std::make_pair(value, tr);
 }
 std::shared_ptr<Block::Entry> Block::get_entry(std::size_t offset) {
   if (offset > Offset_[Offset_.size() - 1]) {
@@ -307,7 +305,7 @@ size_t Block::get_cur_size() const {
   return Data_.size() + Offset_.size() * sizeof(uint16_t) + sizeof(uint16_t);
 }
 
-std::optional<std::pair<std::string_view, uint64_t>> Block::get_value_binary(std::string_view key) {
+std::optional<std::pair<std::string, uint64_t>> Block::get_value_binary(std::string_view key) {
   auto idx = get_offset_binary(key);
   if (idx.has_value()) {
     return get_value(idx->first);

--- a/src/storage/Sstable.cpp
+++ b/src/storage/Sstable.cpp
@@ -211,13 +211,9 @@ std::string Sstable::get_last_key() const {
 bool Sstable::is_block_index_vaild(size_t block_idx) const {
   return block_idx < block_metas.size() ? true : false;
 }
-std::optional<std::pair<std::string_view, uint64_t>> Sstable::KeyExists(std::string_view key,
-                                                                        uint64_t         tranc_id) {
+std::optional<std::pair<std::string, uint64_t>> Sstable::KeyExists(std::string_view key,
+                                                                   uint64_t         tranc_id) {
   if (key < first_key || key > last_key) {
-    return std::nullopt;
-  }
-  // 先在布隆过滤器判断key是否存在
-  if (bloom_filter != nullptr && !bloom_filter->possibly_contains(key)) {
     return std::nullopt;
   }
   auto block_idx_opt = find_block_idx(key);
@@ -226,7 +222,7 @@ std::optional<std::pair<std::string_view, uint64_t>> Sstable::KeyExists(std::str
   }
   auto block = read_block(block_idx_opt.value());
   auto res   = block->get_value_binary(key);
-  if (res.has_value() && res->second < tranc_id) {
+  if (res.has_value() && res->second <= tranc_id) {
     return res;
   }
   return std::nullopt;

--- a/src/storage/file.cpp
+++ b/src/storage/file.cpp
@@ -128,6 +128,12 @@ bool FileObj::append(std::vector<uint8_t>& buffer) {
   return true;
 }
 
+bool FileObj::is_open() {
+  if (!m_file) {
+    return false;
+  }
+  return m_file->is_open();
+}
 bool FileObj::sync() {
   if (!m_file) {
     return false;

--- a/src/storage/std_file.cpp
+++ b/src/storage/std_file.cpp
@@ -1,101 +1,85 @@
 #include "../../include/storage/file.h"
-#include <iostream>
-
-// 打开文件，可选择创建新文件
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
 #include <filesystem>
+#include <stdexcept>
+#include <iostream>
+#include <cstdio>
 
 bool StdFile::open(const std::string& filename, bool create) {
   filename_ = filename;
 
-  if (create) {
-    // 创建空文件
-    std::ofstream(filename, std::ios::binary | std::ios::trunc).close();
-  } else if (!std::filesystem::exists(filename)) {
-    std::cerr << "File does not exist: " << filename << std::endl;
-    return false;  // 文件不存在，返回错误
-  }
+  int flags = create ? (O_RDWR | O_CREAT | O_TRUNC) : O_RDWR;
+  fd_       = ::open(filename.c_str(), flags, 0644);
 
-  // 尝试以读写模式打开
-  file_.open(filename, std::ios::in | std::ios::out | std::ios::binary);
-
-  if (!file_.is_open()) {
+  if (fd_ < 0) {
     std::cerr << "Failed to open file: " << filename << std::endl;
     perror("Error");
+    return false;
   }
-
-  return file_.is_open();
+  return true;
 }
-// 创建文件并写入数据
+
+bool StdFile::is_open() const {
+  return fd_ >= 0;
+}
+
 bool StdFile::create(const std::string& filename, const std::vector<uint8_t>& data) {
   if (!open(filename, true)) {
     return false;
   }
   if (!data.empty()) {
-    file_.seekp(0);
-    file_.write(reinterpret_cast<const char*>(data.data()), data.size());
-    file_.flush();
+    ssize_t n = ::pwrite(fd_, data.data(), data.size(), 0);
+    if (n < 0 || static_cast<size_t>(n) != data.size()) {
+      return false;
+    }
+    ::fsync(fd_);
   }
-  return file_.good();
+  return true;
 }
 
-// 读取数据
-std::vector<uint8_t> StdFile::read(size_t offset = 0, size_t length = SIZE_MAX) {
-  if (!file_.is_open())
-    throw std::runtime_error("File not open");
-
+// pread 不修改文件偏移，多线程并发读安全
+std::vector<uint8_t> StdFile::read(size_t offset, size_t length) {
   size_t file_size = size();
   if (offset >= file_size)
-    throw std::out_of_range("Offset is beyond file size");
+    throw std::out_of_range("Offset beyond file size");
 
   size_t               read_size = std::min(length, file_size - offset);
   std::vector<uint8_t> buffer(read_size);
 
-  file_.seekg(offset);
-  file_.read(reinterpret_cast<char*>(buffer.data()), read_size);
+  ssize_t n = ::pread(fd_, buffer.data(), read_size, static_cast<off_t>(offset));
+  if (n < 0)
+    throw std::runtime_error("pread failed");
 
-  buffer.resize(file_.gcount());  // 调整为实际读取大小
+  buffer.resize(static_cast<size_t>(n));
   return buffer;
 }
-// 关闭文件
+
 void StdFile::close() {
-  if (file_.is_open()) {
-    sync();
-    file_.close();
+  if (fd_ >= 0) {
+    ::fsync(fd_);
+    ::close(fd_);
+    fd_ = -1;
   }
 }
 
-// 获取文件大小
-size_t StdFile::size() {
-  if (!file_.is_open()) {
-    throw std::runtime_error("File not open");
-  }
-  auto current_pos = file_.tellg();
-  file_.seekg(0, std::ios::end);
-  size_t file_size = file_.tellg();
-  file_.seekg(current_pos, std::ios::beg);  // 恢复原位置
-  return file_size;
+size_t StdFile::size() const {
+  struct stat st;
+  if (::fstat(fd_, &st) < 0)
+    throw std::runtime_error("fstat failed");
+  return static_cast<size_t>(st.st_size);
 }
 
-// 从指定偏移写入数据
-bool StdFile::write(size_t offset, const void* data, size_t size) {
-  if (!file_.is_open()) {
-    return false;
-  }
-  file_.seekp(offset, std::ios::beg);
-  file_.write(static_cast<const char*>(data), size);
-  return file_.good();
+bool StdFile::write(size_t offset, const void* data, size_t sz) {
+  ssize_t n = ::pwrite(fd_, data, sz, static_cast<off_t>(offset));
+  return n == static_cast<ssize_t>(sz);
 }
 
-// 同步数据到磁盘
 bool StdFile::sync() {
-  if (!file_.is_open()) {
-    return false;
-  }
-  file_.flush();
-  return file_.good();
+  return ::fsync(fd_) == 0;
 }
 
-// 删除文件
 bool StdFile::remove() {
   close();
   return std::remove(filename_.c_str()) == 0;

--- a/src/storage/wal.cpp
+++ b/src/storage/wal.cpp
@@ -3,8 +3,6 @@
 #include <algorithm>
 #include <array>
 #include <filesystem>
-#include <ranges>
-#include <stdexcept>
 
 // ─── CRC-32C (Castagnoli) ─────────────────────────────────────────────────────
 namespace {
@@ -61,8 +59,6 @@ template <std::integral T>
 
 }  // namespace
 
-// ─── Constructor ─────────────────────────────────────────────────────────────
-
 WAL::WAL(std::string_view log_dir, uint64_t checkpoint_tranc_id, uint64_t clean_interval_s,
          uint64_t file_size_limit)
     : file_size_limit_(file_size_limit),
@@ -80,10 +76,12 @@ WAL::WAL(std::string_view log_dir, uint64_t checkpoint_tranc_id, uint64_t clean_
   cleaner_thread_ = std::thread(&WAL::cleaner, this);
 }
 
-// ─── Destructor ───────────────────────────────────────────────────────────────
-
 WAL::~WAL() {
-  flush();  // ensure everything is fsync'd
+  if (auto result = flush(); !result) {
+    // 记录错误，例如写入 stderr 或日志文件
+    std::fprintf(stderr, "WAL flush failed during destruction: error %d\n",
+                 static_cast<int>(result.error()));
+  }
 
   {
     std::lock_guard lk(cleaner_mutex_);
@@ -96,8 +94,6 @@ WAL::~WAL() {
   log_file_.close();
 }
 
-// ─── flush ────────────────────────────────────────────────────────────────────
-
 std::expected<void, WalError> WAL::flush() {
   std::lock_guard lk(write_mutex_);
   if (!log_file_.sync())
@@ -105,23 +101,59 @@ std::expected<void, WalError> WAL::flush() {
   return {};
 }
 
-// ─── set_checkpoint_tranc_id ──────────────────────────────────────────────────
-
 void WAL::set_checkpoint_tranc_id(uint64_t id) noexcept {
   std::lock_guard lk(cp_mutex_);
   checkpoint_tranc_id_ = id;
 }
 
-// ─── log (policy dispatch) ────────────────────────────────────────────────────
-
 std::expected<void, WalError> WAL::log(const WalEntry& entry) {
-  if constexpr (Global_::WAL_WRITE_POLICY == Global_::WalWritePolicy::kPipelined)
+  if constexpr (Global_::WAL_WRITE_POLICY == Global_::WalWritePolicy::kPipelined) {
     return log_pipelined(entry);
-  else
+  } else {
     return log_unordered(entry);
+  }
 }
 
-// ─── Unordered path ───────────────────────────────────────────────────────────
+// ─── log_batch ────────────────────────────────────────────────────────────────
+//
+//  Writes every entry in `entries` to the WAL and issues exactly one fsync,
+//  regardless of WAL_WRITE_POLICY.  Holding write_mutex_ for the full batch
+//  provides atomic durability: either all entries are fsynced or the call
+//  returns an error.
+//
+//  Design notes:
+//  • Bypassing pipelining is intentional – a batch is already a "group write"
+//    and grouping groups adds no benefit.
+//  • Concurrent single log() calls in kPipelined mode will queue behind this
+//    batch's write_mutex_ hold, which is correct behaviour.
+//  • On error, entries already written to the kernel buffer are NOT rolled
+//    back.  Callers must treat a WAL write failure as fatal and stop accepting
+//    new writes.
+
+std::expected<void, WalError> WAL::log_batch(std::span<const WalEntry> entries) {
+  if (entries.empty())
+    return {};
+
+  std::lock_guard lk(write_mutex_);
+
+  for (const auto& e : entries) {
+    if (auto r = write_entry_blocks(e); !r)
+      return r;
+  }
+
+  if (log_file_.size() > file_size_limit_) {
+    // Rolling the file here keeps each WAL segment bounded; the cleaner will
+    // eventually remove segments whose entries are all checkpointed.
+    reset_file();
+    // reset_file() does its own fsync on the old file before rotating.
+    return {};
+  }
+
+  if (!log_file_.sync())
+    return std::unexpected(WalError::kSyncFailed);
+
+  return {};
+}
 // Each caller independently serialises through write_mutex_.
 // No grouping; lock is held only for one entry's write + fsync.
 
@@ -135,21 +167,6 @@ std::expected<void, WalError> WAL::log_unordered(const WalEntry& entry) {
     return std::unexpected(WalError::kSyncFailed);
   return {};
 }
-
-// ─── Pipelined path ───────────────────────────────────────────────────────────
-//
-//  Timeline (T1 = leader, T2/T3 = followers):
-//
-//   T1: enqueue → try_lock(write_mutex_) succeeds
-//       → drain queue (may collect T2 if T2 already enqueued)
-//       → write WAL for whole group
-//       → fsync
-//       → signal all members (sets done=true on their Writers)
-//       → release write_mutex_           ← T3 can start its WAL write HERE
-//   T1: sees done=true on its own Writer, returns
-//   T1: caller writes MemTable           ← parallel with T3's WAL write
-//
-//  Followers wait on their Writer::cv; they never hold write_mutex_.
 
 std::expected<void, WalError> WAL::log_pipelined(const WalEntry& entry) {
   Writer w{.entry = entry};
@@ -197,14 +214,15 @@ std::expected<void, WalError> WAL::write_group(std::span<Writer*> group) {
     if (auto r = write_entry_blocks(w->entry); !r)
       return r;
   }
-  if (log_file_.size() > file_size_limit_)
+  if (log_file_.size() > file_size_limit_) {
     reset_file();
+    return {};
+  }
+
   if (!log_file_.sync())
     return std::unexpected(WalError::kSyncFailed);
   return {};
 }
-
-// ─── Block-level I/O ─────────────────────────────────────────────────────────
 
 std::expected<void, WalError> WAL::write_entry_blocks(const WalEntry& entry) {
   const auto               payload = encode_payload(entry);
@@ -345,7 +363,7 @@ std::expected<std::map<uint64_t, std::vector<WalEntry>>, WalError> WAL::recover(
   std::ranges::sort(wal_files);
 
   for (const auto& [unused_sq, path] : wal_files) {
-    auto                 file      = FileObj::open(path, /*create=*/false);
+    auto                 file      = FileObj::open(path, false);
     size_t               file_size = file.size();
     size_t               offset    = 0;
     std::vector<uint8_t> scratch;  // accumulates record fragments
@@ -371,17 +389,14 @@ std::expected<std::map<uint64_t, std::vector<WalEntry>>, WalError> WAL::recover(
       }
 
       // Verify checksum
-      {
-        auto                 data = file.read_to_slice(offset + kHeaderSize, rec_len);
-        std::vector<uint8_t> check;
-        check.reserve(1 + rec_len);
-        check.push_back(rec_type);
-        check.insert(check.end(), data.begin(), data.end());
-        if (crc32c(std::span{check}) != stored_crc)
-          return std::unexpected(WalError::kChecksumMismatch);
-      }
+      auto                 data = file.read_to_slice(offset + kHeaderSize, rec_len);
+      std::vector<uint8_t> check;
+      check.reserve(1 + rec_len);
+      check.push_back(rec_type);
+      check.insert(check.end(), data.begin(), data.end());
+      if (crc32c(std::span{check}) != stored_crc)
+        return std::unexpected(WalError::kChecksumMismatch);
 
-      auto data = file.read_to_slice(offset + kHeaderSize, rec_len);
       offset += kHeaderSize + rec_len;
 
       bool complete = false;
@@ -495,6 +510,10 @@ std::vector<uint64_t> WAL::scan_tranc_ids(FileObj& file) noexcept {
 // ─── reset_file ──────────────────────────────────────────────────────────────
 
 void WAL::reset_file() {
+  if (log_file_.is_open()) {
+    log_file_.sync();  // 确保数据持久化
+    log_file_.close();
+  }
   const auto dot   = active_log_path_.find_last_of('.');
   const auto seq   = std::stoul(active_log_path_.substr(dot + 1)) + 1;
   active_log_path_ = active_log_path_.substr(0, dot + 1) + std::to_string(seq);
@@ -550,8 +569,8 @@ void WAL::cleanWALFile() {
   if (wal_files.size() <= 1)
     return;
 
-  for (size_t i = 0; i + 1 < wal_files.size(); ++i) {
-    auto       file = FileObj::open(wal_files[i].second, /*create=*/false);
+  for (auto& it : wal_files) {
+    auto       file = FileObj::open(it.second, false);
     const auto ids  = scan_tranc_ids(file);
 
     // Safe to delete only when every recorded tranc_id has been checkpointed.


### PR DESCRIPTION
Format storage module files with clang-format

- Block.h/cpp
- Sstable.h/cpp
- file.h/.cpp/std_file.h/cpp
- wal.h/cpp

Standardizes formatting across storage layer